### PR TITLE
update snirf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.19.5
+numpy==2.2
 snirf==0.8.0
 importlib_resources==5.4.0
 tabulate==0.8.9
-pandas==1.3.5
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==2.2
+numpy==2.0.2
 snirf==0.8.0
 importlib_resources==5.4.0
 tabulate==0.8.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
-pysnirf2==0.6.2
+snirf==0.8.0
 importlib_resources==5.4.0
 tabulate==0.8.9
 pandas==1.3.5

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ about['__version__'] = VERSION
 REQUIRED = [
     'numpy',
     'setuptools',
-    'pysnirf2',
+    'snirf',
     'importlib_resources'
 ]
 

--- a/snirf2bids/snirf2bids.py
+++ b/snirf2bids/snirf2bids.py
@@ -11,7 +11,7 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 import importlib_resources
-from pysnirf2 import Snirf, SnirfFormatError
+from snirf import Snirf, SnirfFormatError
 
 try:
     from snirf2bids.__version__ import __version__ as __version__


### PR DESCRIPTION
This pull request updates snirf2bids to ensure compatibility with the latest NumPy releases.

- Replaces pysnirf2 with snirf
- Update snirf version to 0.8.0